### PR TITLE
Refactor: Remove unnecessary `ser.index.name = "ts"`

### DIFF
--- a/custom_calculations_scripts/coolprop_examples/heat_exchanger_energy_flow.py
+++ b/custom_calculations_scripts/coolprop_examples/heat_exchanger_energy_flow.py
@@ -77,6 +77,5 @@ df = df.loc[
 
 ser = pd.Series(df["value"].values, index=df.index)
 ser.name = "value"
-ser.index.name = "ts"
 
 ser.to_csv(os.environ["OUTPUT_FILE"])

--- a/custom_calculations_scripts/regular_intervals_examples/incrementing_counter.py
+++ b/custom_calculations_scripts/regular_intervals_examples/incrementing_counter.py
@@ -98,7 +98,6 @@ for interval in intervals:
 # Concatenate the series
 ser = pd.concat(ser_list)
 ser.name = "value"
-ser.index.name = "ts"
 
 # Filter for timestamps and NaN values
 ser = (

--- a/custom_calculations_scripts/regular_intervals_examples/incrementing_totalizer.py
+++ b/custom_calculations_scripts/regular_intervals_examples/incrementing_totalizer.py
@@ -64,7 +64,6 @@ for interval in intervals:
 # Concatenate the series
 ser = pd.concat(ser_list)
 ser.name = "value"
-ser.index.name = "ts"
 
 # Filter for timestamps and NaN values
 ser = (

--- a/custom_calculations_scripts/search_results_examples/block_aggregations_calc_search_results.py
+++ b/custom_calculations_scripts/search_results_examples/block_aggregations_calc_search_results.py
@@ -84,8 +84,6 @@ ser = pd.Series(
     ],
 )
 
-ser.index.name = "ts"
-
 # Filter for timestamps and NaN values
 ser = (
     ser

--- a/custom_calculations_scripts/search_results_examples/event_counter_for_search_results.py
+++ b/custom_calculations_scripts/search_results_examples/event_counter_for_search_results.py
@@ -86,8 +86,6 @@ ser = pd.Series(
     ],
 )
 
-ser.index.name = "ts"
-
 # Filter for timestamps and NaN values
 ser = (
     ser

--- a/custom_calculations_scripts/search_results_examples/incrementing_event_counter_search_results.py
+++ b/custom_calculations_scripts/search_results_examples/incrementing_event_counter_search_results.py
@@ -105,7 +105,6 @@ for interval in intervals:
 # Concatenate the series
 ser = pd.concat(ser_list)
 ser.name = "value"
-ser.index.name = "ts"
 
 # Filter for timestamps and NaN values
 ser = (

--- a/custom_calculations_scripts/search_results_examples/incrementing_value_totalizer_search_results.py
+++ b/custom_calculations_scripts/search_results_examples/incrementing_value_totalizer_search_results.py
@@ -84,7 +84,6 @@ for interval in intervals:
 # Concatenate the series
 ser = pd.concat(ser_list)
 ser.name = "value"
-ser.index.name = "ts"
 
 # Filter for timestamps and NaN values
 ser = (


### PR DESCRIPTION
This commit removes all occurrences of `ser.index.name = "ts"` from files in the `custom_calculations_scripts` folder. This line of code was redundant as the index name is already set to "ts" by default in these scripts.